### PR TITLE
Change default behaviours for module generation by users

### DIFF
--- a/config/cirrus-ex-user/modules.yaml
+++ b/config/cirrus-ex-user/modules.yaml
@@ -1,0 +1,34 @@
+modules:
+  default:
+    'enable:':
+    - lmod
+    roots:
+      lmod: $user_cache_path/modules
+    lmod:
+      hash_length: 0
+      core_compilers: [gcc,cce,intel-oneapi-compilers] # Disable using compiler hierarchy
+      hide_implicits: true
+      all:
+        autoload: run
+      
+      exclude:
+      - cray-mpich
+      - cray-libsci
+      - libfabric
+      - fftw
+      - hdf5
+      - cray-fftw
+      - parallel-netcdf
+      - netcdf-cxx4
+      - netcdf-fortran
+    arch_folder: false
+  
+  prefix_inspections:
+    ./lib:
+      - LD_LIBRARY_PATH
+      - LIBRARY_PATH
+    ./lib64:
+      - LD_LIBRARY_PATH
+      - LIBRARY_PATH
+    ./include:
+      - CPATH

--- a/config/cirrus-ex-user/modules.yaml
+++ b/config/cirrus-ex-user/modules.yaml
@@ -6,6 +6,7 @@ modules:
       lmod: $env/modules
     lmod:
       hash_length: 0
+      hierarchy:: [] # Disable using mpi hierarchy
       core_compilers: [gcc,cce,intel-oneapi-compilers] # Disable using compiler hierarchy
       hide_implicits: true
       all:
@@ -22,6 +23,7 @@ modules:
       - netcdf-cxx4
       - netcdf-fortran
     arch_folder: false
+
   
   prefix_inspections:
     ./lib:

--- a/config/cirrus-ex-user/modules.yaml
+++ b/config/cirrus-ex-user/modules.yaml
@@ -3,7 +3,7 @@ modules:
     'enable:':
     - lmod
     roots:
-      lmod: $user_cache_path/modules
+      lmod: $env/modules
     lmod:
       hash_length: 0
       core_compilers: [gcc,cce,intel-oneapi-compilers] # Disable using compiler hierarchy

--- a/environments/cirrus-ex-cse/modules.yaml
+++ b/environments/cirrus-ex-cse/modules.yaml
@@ -24,7 +24,7 @@
         - netcdf-fortran
 
         hash_length: 0
-        core_compilers: [gcc@14.2.1,none]
+        core_compilers:: [gcc@14.2.1,none]
 
         hide_implicits: true
         all:

--- a/environments/cirrus-ex-openmpi/modules.yaml
+++ b/environments/cirrus-ex-openmpi/modules.yaml
@@ -24,7 +24,7 @@
         - netcdf-fortran
 
         hash_length: 0
-        core_compilers: [gcc@14.2.1,none]
+        core_compilers:: [gcc@14.2.1,none]
 
         hide_implicits: true
         all:


### PR DESCRIPTION
One of the issues with `spack load <package_name>` , is that it will not set environment variables such as LD_LIBRARY_PATH, CPATH, LIBRARY_PATH etc... . That means it is difficult for users to use libraries, as they will not be picked up automatically from the build system. However one can configure spack to generate modules which will set those packages. 

Here I change the default behaviour for modules generated by users. We can then update the cirrus documentation, to tell people how to generate their own modules.

This should make it easier for users to install their own software.

- I have checked using `spack config blame` that the cse environment is unchanged, except for setting CPATH and LIBRARY_PATH on newly generated modules ( this can be avoided, but I think it is a good change ) .
- I am not using the hierarchy, as the generated modules are more difficult to integrate with the cray programming environment, and cause issues when the packages do not fit inside the hierarchy. I feel that is too complicated for users un-familiar with spack ( or hpc in general ). The idea is to have a module interface to an environment which feels as much as possible similar to a python virtual environment.
- If modules are generated outside an environment it should return a permission denied error , as it tries to write in the configuration folder. If generated inside an environment, the modules are generated in the `modules` subdirectory .


User instructions would be to create an environment and then generate the modules

```bash
spack env create -d my_test_env
spack env activate my_test_env
spack add gromacs %gcc
sack install 
spack module lmod refresh
module use my_test_env/modules/Core
module load gromacs
```

Triggered by https://safe.epcc.ed.ac.uk/TransitionServlet/Query/2952613 .