### PR TITLE
Fix default Lmod modulefile root to avoid errors when no environment is active

### DIFF
--- a/config/cirrus-ex-user/modules.yaml
+++ b/config/cirrus-ex-user/modules.yaml
@@ -3,7 +3,7 @@ modules:
     'enable:':
     - lmod
     roots:
-      lmod: $env/modules
+      lmod: $user_cache_path/share/spack/modules
     lmod:
       hash_length: 0
       hierarchy:: [] # Disable using mpi hierarchy


### PR DESCRIPTION
Fixes a potential issue with Spack modulefile generation on Cirrus. Previously, the default `roots.lmod` was set to `$env/modules`, which caused `spack install` and modulefile commands to fail if no Spack environment was active.

The change updates the default root to `$user_cache_path/share/spack/modules`, resulting in:
* Modulefiles generated in a user-writable location even without an active environment.
* `spack install` and `spack module lmod refresh` not leading to an error.

Example usage after this change:

```bash
spack install <package>
spack module lmod refresh --delete-tree -y
module use $SPACK_USER_CONFIG_PATH/share/spack/modules/Core
module load <package>
```

The path to module files can also be changed:

```bash
spack config add "modules:default:roots:lmod:<full_path_to_modulefiles>"
spack module lmod refresh --delete-tree -y
module use <full_path_to_modulefiles>
```